### PR TITLE
1829: Remove buttons to start and stop time tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-21](https://github.com/itk-kimai/AarhusKommuneBundle/pull/21)
+  1829: Hide start and stop timetracking on timesheet column actions
 * [PR-20](https://github.com/itk-kimai/AarhusKommuneBundle/pull/20)
   1711: Added No tracking tracking mode
 * [PR-19](https://github.com/itk-kimai/AarhusKommuneBundle/pull/19)

--- a/Resources/public/styles.css
+++ b/Resources/public/styles.css
@@ -56,12 +56,13 @@ form[name="timesheet_visibility"] .form-selectgroup-item:has(#column_exported),
 .user-year-reporting-box tr.project,
 .user-year-reporting-box tfoot,
 
-/* Hide summery on quick_entry_box table */
-#quick_entry_box tfoot,
-
 /* Hide create button on timesheet */
 .timesheet .page-actions .action-create,
 .timesheet .page-actions .pa-mobile,
+
+/* Hide start button on timesheet col actions */
+.timesheet .col_actions .dd-ts-repeat,
+.timesheet .col_actions .dd-ts-stop,
 
 /* Hide edit button on timesheet (When entry is selected)*/
 #multi_update_form #multi_update_table_action_0,
@@ -89,4 +90,9 @@ form[name="timesheet_edit_form"] label[for="timesheet_edit_form_duration"] {
   height: 32px;
   margin-right: 41px;
   margin-bottom: 4px;
+}
+@media (max-width: 992px) {
+    form[name="timesheet_edit_form"] label[for="timesheet_edit_form_duration"] {
+        margin-right: 11px;
+    }
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=timesheet#/tickets/showTicket/1829

#### Description

* Reintroduce summery on weekly hours
* Fix margin bug on timesheet modal in tablet view
* Remove time tracking buttons.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
