### PR TITLE
Prevent editing timesheet begin and end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-23](https://github.com/itk-kimai/AarhusKommuneBundle/pull/23)
+  Prevent editing timesheet begin and end
 * [PR-22](https://github.com/itk-kimai/AarhusKommuneBundle/pull/22)
   1855: Change title on login
 * [PR-21](https://github.com/itk-kimai/AarhusKommuneBundle/pull/21)

--- a/TrackingMode/NoTrackingMode.php
+++ b/TrackingMode/NoTrackingMode.php
@@ -26,12 +26,12 @@ final class NoTrackingMode extends AbstractTrackingMode
 
     public function canEditBegin(): bool
     {
-        return true;
+        return false;
     }
 
     public function canEditEnd(): bool
     {
-        return true;
+        return false;
     }
 
     public function canEditDuration(): bool


### PR DESCRIPTION
https://leantime.itkdev.dk/tickets/showKanban?tab=ticketdetails#/tickets/showTicket/1854

Prevents editing timesheet begin and end (times) when using “No tracking” mode.