### PR TITLE
7596: Register plugin migrations in install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* 7596: Register plugin migrations in install command so
+  `kimai:bundle:aarhus_kommune:install` runs them automatically.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation
 * [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* 7596: Register plugin migrations in install command so
+* [PR-36](https://github.com/itk-kimai/AarhusKommuneBundle/pull/36)
+  7596: Register plugin migrations in install command so
   `kimai:bundle:aarhus_kommune:install` runs them automatically.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation

--- a/Command/InstallCommand.php
+++ b/Command/InstallCommand.php
@@ -24,4 +24,9 @@ class InstallCommand extends AbstractBundleInstallerCommand
     {
         return true;
     }
+
+    protected function getMigrationConfigFilename(): ?string
+    {
+        return __DIR__.'/../Migrations/aarhus_kommune.yaml';
+    }
 }

--- a/Migrations/aarhus_kommune.yaml
+++ b/Migrations/aarhus_kommune.yaml
@@ -4,7 +4,6 @@
 #
 # Execute all migrations with:
 # bin/console kimai:bundle:aarhus_kommune:install
-# bin/console doctrine:migrations:migrate --em=default --configuration=var/plugins/AarhusKommuneBundle/Migrations/aarhus_kommune.yaml
 # --------------------------------------------------------------------------------------------------
 
 table_storage:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Download [a release](https://github.com/itk-kimai/AarhusKommuneBundle/releases) and extract it to `var/plugins/`.
 
 ```shell
-# Install plugin assets in public/bundles/aarhuskommune (note it's "aarhuskommune" and not "aarhus_kommune").
-# Use "/bundles/aarhuskommune/" as base path when referencing assets..
+# Installs plugin assets to public/bundles/aarhuskommune (note "aarhuskommune", not "aarhus_kommune")
+# and applies the plugin's doctrine migrations.
+# Use "/bundles/aarhuskommune/" as base path when referencing assets.
 bin/console kimai:bundle:aarhus_kommune:install --no-interaction
-bin/console doctrine:migrations:migrate --configuration=var/plugins/AarhusKommuneBundle/Migrations/aarhus_kommune.yaml --no-interaction
 bin/console kimai:reload --no-interaction
 ```
 


### PR DESCRIPTION
## Summary

`kimai:bundle:aarhus_kommune:install` does not currently run the plugin's doctrine migrations, because `InstallCommand` only overrides `hasAssets()` and leaves `getMigrationConfigFilename()` at the default (returns `null`, so `AbstractBundleInstallerCommand` skips the migration step entirely).

That means deploy and update flows have to call `doctrine:migrations:migrate --configuration=var/plugins/AarhusKommuneBundle/Migrations/aarhus_kommune.yaml` explicitly to apply plugin migrations — easy to forget, and silently no-ops in the install command (no warning, no error).

This PR aligns `AarhusKommuneBundle` with `AakSamlBundle` and `TranslationBundle`, both of which override `getMigrationConfigFilename()` so their install commands are self-contained.

## Files Changed

* `Command/InstallCommand.php` — override `getMigrationConfigFilename()` to return the plugin's migration config path.
* `CHANGELOG.md` — entry under `[Unreleased]`.

## Test Plan

1. On a Kimai instance with this plugin removed (or migration table empty), run `bin/console kimai:bundle:aarhus_kommune:install`.
2. Expected: `Version20240628091807` is applied; `bundle_migration_aarhus_kommune` table is created and contains the executed migration.
3. Re-run the command — expected: idempotent (no migration to apply, command succeeds).
4. Confirm assets are still installed (existing `hasAssets()` behavior is unchanged).

Closes #7596