### PR TITLE
7596: Replace deprecated kimai_config accessor with config() for Kimai 2.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* 7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
+  template accessors with `config(...)`; required for Kimai 2.57 compatibility.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation
 * [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* 7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
+* [PR-37](https://github.com/itk-kimai/AarhusKommuneBundle/pull/37)
+  7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
   template accessors with `config(...)`; required for Kimai 2.57 compatibility.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation

--- a/Resources/views/app/base.html.twig
+++ b/Resources/views/app/base.html.twig
@@ -1,7 +1,7 @@
 {# Resources/views/app/base.html.twig #}
 {% extends '@App/base.html.twig' %}
 
-{% set meta_title = kimai_config.get('aarhuskommune.meta-title') %}
+{% set meta_title = config('aarhuskommune.meta-title') %}
 
 {% block body_start %}
     class="{{ app.request.attributes.get('_route')|slug|lower }}"
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block page_content_after %}
-    {% set help_url = kimai_config.get('aarhuskommune.help_url') %}
+    {% set help_url = config('aarhuskommune.help_url') %}
     {% if help_url|default(false) %}
         <div class="float-help">
             <a href="{{ help_url }}" target="_blank" accesskey="h" title="{{ 'help'|trans }}">

--- a/Resources/views/app/security/login.html.twig
+++ b/Resources/views/app/security/login.html.twig
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block title %}
-    {% set meta_title = kimai_config.get('aarhuskommune.meta-title') %}
+    {% set meta_title = config('aarhuskommune.meta-title') %}
     {% if meta_title is not empty %}
         {{ meta_title|raw }}
     {% else %}
@@ -42,11 +42,11 @@
 
         <div class="card-body">
             <div class="row text-center">
-                {% set social_login_title = kimai_config.get('aarhuskommune.social_login_title') %}
+                {% set social_login_title = config('aarhuskommune.social_login_title') %}
                 {% if social_login_title is not empty %}
                     <h1>{{ social_login_title|raw }}</h1>
                 {% endif %}
-                {% if not kimai_config.loginFormActive %}
+                {% if not config('loginFormActive') %}
                     <h2 class="card-title text-center mb-4">{{ block('login_box_msg') }}</h2>
                 {% endif %}
                 <div class="col">
@@ -58,7 +58,7 @@
                 </div>
             </div>
         </div>
-        {% set login_message = kimai_config.get('aarhuskommune.login_message') %}
+        {% set login_message = config('aarhuskommune.login_message') %}
         {% if login_message is not empty %}
             <div class="card-body login-message">
                 {{ login_message|raw }}


### PR DESCRIPTION
## Summary

Kimai 2.57 changed `App\Twig\Configuration::get()` to take a `Twig\Environment` as its first argument, and the `kimai_config` Twig global is now a deprecation stub whose `__call` always returns null. Six call sites in this bundle's templates still used the old `kimai_config.get('...')` / `kimai_config.loginFormActive` accessor syntax.

When Twig resolves `kimai_config.get('...')` it calls `Configuration::get('aarhuskommune.meta-title')` directly with just the string, without injecting `Environment`, so PHP raises a `TypeError` and the login page (and any page extending `base.html.twig`) returns HTTP 500.

This change updates every site to the supported `config('key')` Twig function, which is registered with `needs_environment: true` (Kimai's `src/Twig/Configuration.php:29`) and matches how Kimai core templates currently read configuration values.

## Files Changed

* `Resources/views/app/base.html.twig` — 2 call sites (`meta-title`, `help_url`).
* `Resources/views/app/security/login.html.twig` — 4 call sites (`meta-title`, `social_login_title`, `loginFormActive`, `login_message`).
* `CHANGELOG.md` — entry under `[Unreleased]`.

## Test Plan

1. Run a Kimai 2.57 instance with this bundle on the **previous** version (1.3.0): visit `/login`, observe HTTP 500 with `App\\Twig\\Configuration::get(): Argument #1 ($environment) must be of type Twig\\Environment, string given`.
2. Apply this PR's checkout, `bin/console kimai:reload`, refresh `/login` — expect HTTP 200, login page renders, SAML button still appears, login form still hidden by default unless `#admin-login` is in the URL.
3. With `aarhuskommune.meta-title`, `aarhuskommune.help_url`, `aarhuskommune.social_login_title`, `aarhuskommune.login_message` set in System Configuration, confirm their values still appear in the rendered output.
4. Navigate to any page after login (which extends `base.html.twig`) — expect HTTP 200, no Twig errors in `var/log/prod-*.log`.

Closes #7596