### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* 7596: Register plugin migrations in install command so
+  `kimai:bundle:aarhus_kommune:install` runs them automatically.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation
 * [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* 7596: Register plugin migrations in install command so
+* [PR-36](https://github.com/itk-kimai/AarhusKommuneBundle/pull/36)
+  7596: Register plugin migrations in install command so
   `kimai:bundle:aarhus_kommune:install` runs them automatically.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* 7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
+  template accessors with `config(...)`; required for Kimai 2.57 compatibility.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation
 * [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* 7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
+* [PR-37](https://github.com/itk-kimai/AarhusKommuneBundle/pull/37)
+  7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
   template accessors with `config(...)`; required for Kimai 2.57 compatibility.
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-26
+
 * [PR-37](https://github.com/itk-kimai/AarhusKommuneBundle/pull/37)
   7596: Replace deprecated `kimai_config.get(...)` / `kimai_config.loginFormActive`
   template accessors with `config(...)`; required for Kimai 2.57 compatibility.
 * [PR-36](https://github.com/itk-kimai/AarhusKommuneBundle/pull/36)
   7596: Register plugin migrations in install command so
   `kimai:bundle:aarhus_kommune:install` runs them automatically.
+
+## [1.3.0] - 2025-09-01
+
 * [PR-32](https://github.com/itk-kimai/AarhusKommuneBundle/pull/32)
   2491: Updated Teamlead permissions documentation
-* [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)
-  Remove prerelease flag in release.yml.
 * [PR-31](https://github.com/itk-kimai/AarhusKommuneBundle/pull/31)
   Code cleanup
+* [PR-29](https://github.com/itk-kimai/AarhusKommuneBundle/pull/30)
+  Remove prerelease flag in release.yml.
 * [PR-28](https://github.com/itk-kimai/AarhusKommuneBundle/pull/28)
   Improved release script
 
@@ -81,7 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [PR-1](https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle/pull/1)
   Added Aarhus kommune plugin
 
-[Unreleased]: https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle/compare/1.2.0...HEAD
-[1.2.0]: https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle/compare/1.0.0...1.2.0
-[1.1.0]: https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle/compare/1.0.0...1.1.0
-[1.0.0]: https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle/releases/tag/1.0.0
+[Unreleased]: https://github.com/itk-kimai/AarhusKommuneBundle/compare/1.4.0...HEAD
+[1.4.0]: https://github.com/itk-kimai/AarhusKommuneBundle/compare/1.3.0...1.4.0
+[1.3.0]: https://github.com/itk-kimai/AarhusKommuneBundle/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/itk-kimai/AarhusKommuneBundle/compare/1.1.0...1.2.0
+[1.1.0]: https://github.com/itk-kimai/AarhusKommuneBundle/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/itk-kimai/AarhusKommuneBundle/releases/tag/1.0.0

--- a/Command/InstallCommand.php
+++ b/Command/InstallCommand.php
@@ -24,4 +24,9 @@ class InstallCommand extends AbstractBundleInstallerCommand
     {
         return true;
     }
+
+    protected function getMigrationConfigFilename(): ?string
+    {
+        return __DIR__.'/../Migrations/aarhus_kommune.yaml';
+    }
 }

--- a/Migrations/aarhus_kommune.yaml
+++ b/Migrations/aarhus_kommune.yaml
@@ -4,7 +4,6 @@
 #
 # Execute all migrations with:
 # bin/console kimai:bundle:aarhus_kommune:install
-# bin/console doctrine:migrations:migrate --em=default --configuration=var/plugins/AarhusKommuneBundle/Migrations/aarhus_kommune.yaml
 # --------------------------------------------------------------------------------------------------
 
 table_storage:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Download [a release](https://github.com/itk-kimai/AarhusKommuneBundle/releases) and extract it to `var/plugins/`.
 
 ```shell
-# Install plugin assets in public/bundles/aarhuskommune (note it's "aarhuskommune" and not "aarhus_kommune").
-# Use "/bundles/aarhuskommune/" as base path when referencing assets..
+# Installs plugin assets to public/bundles/aarhuskommune (note "aarhuskommune", not "aarhus_kommune")
+# and applies the plugin's doctrine migrations.
+# Use "/bundles/aarhuskommune/" as base path when referencing assets.
 bin/console kimai:bundle:aarhus_kommune:install --no-interaction
-bin/console doctrine:migrations:migrate --configuration=var/plugins/AarhusKommuneBundle/Migrations/aarhus_kommune.yaml --no-interaction
 bin/console kimai:reload --no-interaction
 ```
 

--- a/Resources/views/app/base.html.twig
+++ b/Resources/views/app/base.html.twig
@@ -1,7 +1,7 @@
 {# Resources/views/app/base.html.twig #}
 {% extends '@App/base.html.twig' %}
 
-{% set meta_title = kimai_config.get('aarhuskommune.meta-title') %}
+{% set meta_title = config('aarhuskommune.meta-title') %}
 
 {% block body_start %}
     class="{{ app.request.attributes.get('_route')|slug|lower }}"
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block page_content_after %}
-    {% set help_url = kimai_config.get('aarhuskommune.help_url') %}
+    {% set help_url = config('aarhuskommune.help_url') %}
     {% if help_url|default(false) %}
         <div class="float-help">
             <a href="{{ help_url }}" target="_blank" accesskey="h" title="{{ 'help'|trans }}">

--- a/Resources/views/app/security/login.html.twig
+++ b/Resources/views/app/security/login.html.twig
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block title %}
-    {% set meta_title = kimai_config.get('aarhuskommune.meta-title') %}
+    {% set meta_title = config('aarhuskommune.meta-title') %}
     {% if meta_title is not empty %}
         {{ meta_title|raw }}
     {% else %}
@@ -42,11 +42,11 @@
 
         <div class="card-body">
             <div class="row text-center">
-                {% set social_login_title = kimai_config.get('aarhuskommune.social_login_title') %}
+                {% set social_login_title = config('aarhuskommune.social_login_title') %}
                 {% if social_login_title is not empty %}
                     <h1>{{ social_login_title|raw }}</h1>
                 {% endif %}
-                {% if not kimai_config.loginFormActive %}
+                {% if not config('loginFormActive') %}
                     <h2 class="card-title text-center mb-4">{{ block('login_box_msg') }}</h2>
                 {% endif %}
                 <div class="col">
@@ -58,7 +58,7 @@
                 </div>
             </div>
         </div>
-        {% set login_message = kimai_config.get('aarhuskommune.login_message') %}
+        {% set login_message = config('aarhuskommune.login_message') %}
         {% if login_message is not empty %}
             <div class="card-body login-message">
                 {{ login_message|raw }}


### PR DESCRIPTION
Release 1.4.0; restore missing 1.3.0 changelog section

* Add the [1.3.0] section that was never written when tag 1.3.0 was cut on 2025-09-01 (the four PRs sitting under [Unreleased] all predate the 1.3.0 tag commit).
* Promote PR-36 and PR-37 into a new [1.4.0] section dated today.
* Fix the compare-link footer: previous entries incorrectly compared every version against 1.0.0 and pointed at the renamed itk-dev org. All links now use the current itk-kimai org and chain version-to- version.

#### Link to ticket

Please add a link to the ticket being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
