### PR TITLE
7596: Force the UI language to follow the user's preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-XX](https://github.com/itk-kimai/AarhusKommuneBundle/pull/XX)
+  7596: Force the UI language to follow the user's language preference by
+  redirecting authenticated requests whose URL locale differs, and source
+  new-user language, timezone and theme from Kimai's `defaults.user.*`
+  configuration instead of bundle-local defaults.
+
 ## [1.4.0] - 2026-05-26
 
 * [PR-37](https://github.com/itk-kimai/AarhusKommuneBundle/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* [PR-XX](https://github.com/itk-kimai/AarhusKommuneBundle/pull/XX)
+* [PR-39](https://github.com/itk-kimai/AarhusKommuneBundle/pull/39)
   7596: Force the UI language to follow the user's language preference by
   redirecting authenticated requests whose URL locale differs, and source
   new-user language, timezone and theme from Kimai's `defaults.user.*`

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,7 +10,6 @@
 
 namespace KimaiPlugin\AarhusKommuneBundle\DependencyInjection;
 
-use App\Entity\UserPreference;
 use KimaiPlugin\AarhusKommuneBundle\Configuration\AarhusKommuneConfiguration;
 use KimaiPlugin\AarhusKommuneBundle\EventSubscriber\UserSubscriber;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -51,14 +50,12 @@ class Configuration implements ConfigurationInterface
                     ->info('Web Accessibility Statement URL')
                 ->end()
 
-                // language, timezone and theme are taken from Kimai's native
-                // defaults.user.* configuration (applied in createNewUser), so
-                // only the preferences Kimai has no default for live here.
+                // language, timezone and theme come from Kimai's native
+                // defaults.user.* configuration; the formatting locale follows
+                // the language. Only login_initial_view, which Kimai has no
+                // default for, lives here.
                 ->arrayNode('user_defaults')
                     ->children()
-                        ->scalarNode(UserPreference::LOCALE)
-                            ->defaultValue('da')
-                        ->end()
                         ->scalarNode(UserSubscriber::LOGIN_INITIAL_VIEW)
                             ->defaultValue('quick_entry')
                         ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ namespace KimaiPlugin\AarhusKommuneBundle\DependencyInjection;
 
 use App\Entity\UserPreference;
 use KimaiPlugin\AarhusKommuneBundle\Configuration\AarhusKommuneConfiguration;
+use KimaiPlugin\AarhusKommuneBundle\EventSubscriber\UserSubscriber;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -50,21 +51,15 @@ class Configuration implements ConfigurationInterface
                     ->info('Web Accessibility Statement URL')
                 ->end()
 
+                // language, timezone and theme are taken from Kimai's native
+                // defaults.user.* configuration (applied in createNewUser), so
+                // only the preferences Kimai has no default for live here.
                 ->arrayNode('user_defaults')
                     ->children()
-                        ->scalarNode(UserPreference::LANGUAGE)
-                            ->defaultValue('da')
-                        ->end()
                         ->scalarNode(UserPreference::LOCALE)
                             ->defaultValue('da')
                         ->end()
-                        ->scalarNode(UserPreference::TIMEZONE)
-                            ->defaultValue('Europe/Copenhagen')
-                        ->end()
-                        ->scalarNode(UserPreference::SKIN)
-                            ->defaultValue('default')
-                        ->end()
-                        ->scalarNode('login_initial_view')
+                        ->scalarNode(UserSubscriber::LOGIN_INITIAL_VIEW)
                             ->defaultValue('quick_entry')
                         ->end()
                     ->end()

--- a/EventSubscriber/LocaleRedirectSubscriber.php
+++ b/EventSubscriber/LocaleRedirectSubscriber.php
@@ -96,8 +96,7 @@ final readonly class LocaleRedirectSubscriber implements EventSubscriberInterfac
             return;
         }
 
-        // Regenerate the same route with the user's locale instead of rewriting
-        // the path by hand.
+        // Regenerate the route with the user's locale.
         $target = $this->urlGenerator->generate($route, array_merge($routeParams, ['_locale' => $language]));
 
         // Safety net: if _locale is only a route default (not a path segment),

--- a/EventSubscriber/LocaleRedirectSubscriber.php
+++ b/EventSubscriber/LocaleRedirectSubscriber.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the "AarhusKommuneBundle" for Kimai.
+ * All rights reserved by ITK Development (https://github.com/itk-kimai).
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\AarhusKommuneBundle\EventSubscriber;
+
+use App\Configuration\LocaleService;
+use App\Configuration\SystemConfiguration;
+use App\Entity\User;
+use App\Entity\UserPreference;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Forces the UI language to follow the user's preference, regardless of the
+ * {_locale} segment in the URL.
+ *
+ * Kimai derives the UI translation language solely from the {_locale} route
+ * parameter, so a stale /en/ bookmark, browser history or the post-login
+ * target URL renders the wrong language even when the user's preference says
+ * otherwise. This subscriber redirects authenticated GET requests whose URL
+ * locale does not match the user's preferred language to the same path with
+ * the correct locale prefix.
+ *
+ * When a user has no explicit language preference, Kimai's User::getLanguage()
+ * silently falls back to the hard-coded 'en'. To avoid that, the fallback here
+ * is the configured default language (kimai.defaults.user.language), the same
+ * setting Kimai uses when provisioning new users.
+ */
+final readonly class LocaleRedirectSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private SystemConfiguration $systemConfiguration,
+        private LocaleService $localeService,
+    )
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // Runs after Symfony's RouterListener/LocaleListener (priorities 32/16),
+        // so the {_locale} route parameter is already applied to the request.
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 0],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        // Only redirect safe, navigational requests. Never rewrite a POST
+        // (e.g. a form submit or the SAML ACS callback) into a GET.
+        if (!$request->isMethod(Request::METHOD_GET)) {
+            return;
+        }
+
+        $user = $this->tokenStorage->getToken()?->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $language = $this->resolveLanguage($user);
+
+        // Never redirect to a locale Kimai cannot route/translate.
+        if (!$this->localeService->isKnownLocale($language)) {
+            return;
+        }
+
+        // The locale Symfony resolved for this request, taken from the {_locale}
+        // path segment on localized routes. On non-localized routes (/api,
+        // /auth/saml/...) it falls back to the application default; that is
+        // harmless because the anchored rewrite below only fires when the path
+        // actually starts with this locale.
+        $urlLocale = $request->getLocale();
+        if ('' === $urlLocale || $urlLocale === $language) {
+            return;
+        }
+
+        // Rewrite the leading locale segment (e.g. /en/quick_entry/), preserving
+        // the rest of the path. This anchored match is the real guard: a path
+        // that does not start with the locale segment yields no change and we
+        // bail, keeping the URL as the single source of truth.
+        $path = $request->getPathInfo();
+        $count = 0;
+        $newPath = preg_replace(
+            '#^/' . preg_quote($urlLocale, '#') . '(?=/|$)#',
+            '/' . $language,
+            $path,
+            1,
+            $count
+        );
+        if (null === $newPath || 0 === $count) {
+            return;
+        }
+
+        $queryString = $request->getQueryString();
+        $target = $newPath . (null !== $queryString ? '?' . $queryString : '');
+
+        $event->setResponse(new RedirectResponse($target));
+    }
+
+    /**
+     * The user's preferred language, falling back to the configured default
+     * (kimai.defaults.user.language) when no preference is set, instead of
+     * Kimai's hard-coded 'en'.
+     */
+    private function resolveLanguage(User $user): string
+    {
+        $preference = $user->getPreference(UserPreference::LANGUAGE);
+        $value = $preference?->getValue();
+
+        if (\is_string($value) && '' !== $value) {
+            return $value;
+        }
+
+        return $this->systemConfiguration->getUserDefaultLanguage();
+    }
+}

--- a/EventSubscriber/LocaleRedirectSubscriber.php
+++ b/EventSubscriber/LocaleRedirectSubscriber.php
@@ -108,7 +108,9 @@ final readonly class LocaleRedirectSubscriber implements EventSubscriberInterfac
 
         $queryString = $request->getQueryString();
         if (null !== $queryString) {
-            $target .= '?' . $queryString;
+            // generate() may already have appended a query string (route
+            // defaults that are not path segments), so pick the right separator.
+            $target .= (str_contains($target, '?') ? '&' : '?') . $queryString;
         }
 
         $event->setResponse(new RedirectResponse($target));

--- a/EventSubscriber/LocaleRedirectSubscriber.php
+++ b/EventSubscriber/LocaleRedirectSubscriber.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -43,6 +44,7 @@ final readonly class LocaleRedirectSubscriber implements EventSubscriberInterfac
         private TokenStorageInterface $tokenStorage,
         private SystemConfiguration $systemConfiguration,
         private LocaleService $localeService,
+        private UrlGeneratorInterface $urlGenerator,
     )
     {
     }
@@ -82,35 +84,33 @@ final readonly class LocaleRedirectSubscriber implements EventSubscriberInterfac
             return;
         }
 
-        // The locale Symfony resolved for this request, taken from the {_locale}
-        // path segment on localized routes. On non-localized routes (/api,
-        // /auth/saml/...) it falls back to the application default; that is
-        // harmless because the anchored rewrite below only fires when the path
-        // actually starts with this locale.
-        $urlLocale = $request->getLocale();
-        if ('' === $urlLocale || $urlLocale === $language) {
+        // The router has already matched the route (RouterListener, priority 32),
+        // so its parameters carry the {_locale} taken from the path. Routes with
+        // no {_locale} parameter (/api, /auth/saml/...) are left untouched.
+        $route = $request->attributes->get('_route');
+        $routeParams = $request->attributes->get('_route_params', []);
+        if (!\is_string($route) || !\is_array($routeParams) || !\array_key_exists('_locale', $routeParams)) {
+            return;
+        }
+        if ($routeParams['_locale'] === $language) {
             return;
         }
 
-        // Rewrite the leading locale segment (e.g. /en/quick_entry/), preserving
-        // the rest of the path. This anchored match is the real guard: a path
-        // that does not start with the locale segment yields no change and we
-        // bail, keeping the URL as the single source of truth.
-        $path = $request->getPathInfo();
-        $count = 0;
-        $newPath = preg_replace(
-            '#^/' . preg_quote($urlLocale, '#') . '(?=/|$)#',
-            '/' . $language,
-            $path,
-            1,
-            $count
-        );
-        if (null === $newPath || 0 === $count) {
+        // Regenerate the same route with the user's locale instead of rewriting
+        // the path by hand.
+        $target = $this->urlGenerator->generate($route, array_merge($routeParams, ['_locale' => $language]));
+
+        // Safety net: if _locale is only a route default (not a path segment),
+        // generate() appends it as a query parameter and the path is unchanged,
+        // so redirecting would loop. Only redirect when the path actually moves.
+        if (parse_url($target, PHP_URL_PATH) === $request->getPathInfo()) {
             return;
         }
 
         $queryString = $request->getQueryString();
-        $target = $newPath . (null !== $queryString ? '?' . $queryString : '');
+        if (null !== $queryString) {
+            $target .= '?' . $queryString;
+        }
 
         $event->setResponse(new RedirectResponse($target));
     }

--- a/EventSubscriber/UserSubscriber.php
+++ b/EventSubscriber/UserSubscriber.php
@@ -11,7 +11,6 @@
 namespace KimaiPlugin\AarhusKommuneBundle\EventSubscriber;
 
 use App\Entity\User;
-use App\Entity\UserPreference;
 use App\Event\UserCreatePreEvent;
 use KimaiPlugin\AarhusKommuneBundle\Configuration\AarhusKommuneConfiguration;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -44,13 +43,12 @@ class UserSubscriber implements EventSubscriberInterface
             $user->setWizardAsSeen($wizard);
         }
 
-        // language, timezone and theme are applied by Kimai from its
-        // defaults.user.* configuration (UserService::createNewUser). Here we
-        // only set the preferences Kimai has no default for; their values are
-        // declared in the bundle configuration tree (DependencyInjection\Configuration).
+        // Kimai applies language, timezone and theme from defaults.user.*, and
+        // the formatting locale follows the language. Only login_initial_view,
+        // which Kimai has no default for, is set here (value from the bundle
+        // configuration tree).
         $defaults = $this->configuration->getUserDefaults();
 
-        $user->setLocale((string) $defaults[UserPreference::LOCALE]);
         $user->setPreferenceValue(self::LOGIN_INITIAL_VIEW, (string) $defaults[self::LOGIN_INITIAL_VIEW]);
     }
 }

--- a/EventSubscriber/UserSubscriber.php
+++ b/EventSubscriber/UserSubscriber.php
@@ -18,6 +18,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class UserSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Preference key for a user's initial view after login.
+     * (Kimai does not define one)
+     */
+    public const LOGIN_INITIAL_VIEW = 'login_initial_view';
+
     public function __construct(
         private readonly AarhusKommuneConfiguration $configuration
     )
@@ -38,12 +44,13 @@ class UserSubscriber implements EventSubscriberInterface
             $user->setWizardAsSeen($wizard);
         }
 
+        // language, timezone and theme are applied by Kimai from its
+        // defaults.user.* configuration (UserService::createNewUser). Here we
+        // only set the preferences Kimai has no default for; their values are
+        // declared in the bundle configuration tree (DependencyInjection\Configuration).
         $defaults = $this->configuration->getUserDefaults();
 
-        $user->setLanguage($defaults[UserPreference::LANGUAGE] ?? 'da');
-        $user->setLocale($defaults[UserPreference::LOCALE] ?? 'da');
-        $user->setTimezone($defaults[UserPreference::TIMEZONE] ?? 'Europe/Copenhagen');
-        $user->setPreferenceValue(UserPreference::SKIN, $defaults[UserPreference::SKIN] ?? 'default');
-        $user->setPreferenceValue('login_initial_view', $defaults['login_initial_view'] ?? 'quick_entry');
+        $user->setLocale((string) $defaults[UserPreference::LOCALE]);
+        $user->setPreferenceValue(self::LOGIN_INITIAL_VIEW, (string) $defaults[self::LOGIN_INITIAL_VIEW]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ aarhus_kommune:
     # Web Accessibility Statement URL
     was_url: https://was.digst.dk/tid-aarhuskommune-dk
 
-    # language, timezone and theme come from Kimai's defaults.user.* config
-    # (see "User language" below); only the preferences Kimai has no default
-    # for are set here.
+    # The initial view. Language, timezone and theme are set under
+    # kimai.defaults.user.* (see "User language" below).
     user_defaults:
-        !php/const App\Entity\UserPreference::LOCALE: 'da'
         login_initial_view: 'quick_entry'
 
 # Set route on Tabler logo
@@ -74,8 +72,8 @@ redirect to the Web Accessibility Statement URL defined in `local.yaml`.
 
 New users (including those provisioned on first SAML login) get their `language`,
 `timezone` and `theme` from Kimai's native `defaults.user.*` configuration, while
-`locale` and the initial view come from the bundle's `user_defaults` (the two
-preferences Kimai has no default for). Set the Kimai defaults in `local.yaml`:
+the initial view comes from the bundle's `user_defaults`. The formatting locale
+follows the language. Set the Kimai defaults in `local.yaml`:
 
 ``` yaml
 # config/packages/local.yaml

--- a/README.md
+++ b/README.md
@@ -32,18 +32,25 @@ aarhus_kommune:
     # Web Accessibility Statement URL
     was_url: https://was.digst.dk/tid-aarhuskommune-dk
 
+    # language, timezone and theme come from Kimai's defaults.user.* config
+    # (see "User language" below); only the preferences Kimai has no default
+    # for are set here.
     user_defaults:
-        # The default values.
-        !php/const App\Entity\UserPreference::LANGUAGE: 'da'
         !php/const App\Entity\UserPreference::LOCALE: 'da'
-        !php/const App\Entity\UserPreference::TIMEZONE: 'Europe/Copenhagen'
-        !php/const App\Entity\UserPreference::SKIN: 'default'
         login_initial_view: 'quick_entry'
 
 # Set route on Tabler logo
 tabler:
     routes:
         tabler_welcome: quick_entry
+
+# Defaults for newly provisioned users that the bundle defers to Kimai for.
+kimai:
+    defaults:
+        user:
+            language: da
+            timezone: Europe/Copenhagen
+            theme: default
 ```
 
 Use `bin/console debug:config AarhusKommuneBundle` to check the active configuration.
@@ -62,6 +69,31 @@ login form.
 
 The path `/was` (route name: `aarhuskommune_was`) or `/{_locale}/was` (route name: `aarhuskommune_was_locale`) will
 redirect to the Web Accessibility Statement URL defined in `local.yaml`.
+
+### User language
+
+New users (including those provisioned on first SAML login) get their `language`,
+`timezone` and `theme` from Kimai's native `defaults.user.*` configuration, while
+`locale` and the initial view come from the bundle's `user_defaults` (the two
+preferences Kimai has no default for). Set the Kimai defaults in `local.yaml`:
+
+``` yaml
+# config/packages/local.yaml
+kimai:
+    defaults:
+        user:
+            language: da
+            timezone: Europe/Copenhagen
+            theme: default
+```
+
+Kimai derives the UI language solely from the `{_locale}` segment of the URL, so a
+stale `/en/` bookmark, browser history or a post-login target URL renders the wrong
+language even when the user's language preference says otherwise. To prevent this,
+authenticated `GET` requests whose URL locale does not match the user's preferred
+language are redirected to the same path with the correct locale prefix, keeping the
+URL as the source of truth. When a user has no explicit language preference, the
+redirect falls back to the same `kimai.defaults.user.language` value.
 
 ### App template overrides
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             "symfony/runtime": false
         },
         "platform": {
-            "php": "8.1.3"
+            "php": "8.2.0"
         },
         "preferred-install": {
             "*": "dist"


### PR DESCRIPTION
Link to ticket: https://leantime.itkdev.dk/#/tickets/showTicket/7767

Forces the Kimai UI language to follow the user's preference instead of the URL locale, and aligns new-user provisioning with Kimai's native `defaults.user.*` configuration.

## Changes

- Add `LocaleRedirectSubscriber`: redirects authenticated GET requests whose URL locale differs from the user's language preference to the same path with the correct locale, keeping the URL as the source of truth. Regenerates the URL via the router (using the resolved `_route`/`_route_params`), not string rewriting. Falls back to `kimai.defaults.user.language` when no preference is set.
- `UserSubscriber`: stop re-setting language/timezone/theme — `UserService::createNewUser()` already applies those from `defaults.user.*`; only set `locale` and `login_initial_view`. Promote `login_initial_view` to a class constant.
- Shrink the bundle's `user_defaults` config tree to the keys Kimai has no native default for (`locale`, `login_initial_view`); remove hard-coded fallback strings from the subscribers.
- README documentation and `composer.json` platform PHP `8.2`.

## Deployment requirement

Because the bundle no longer sets `language`/`timezone`/`theme` itself, the deployed `local.yaml` must set Kimai's native defaults — otherwise newly provisioned users fall back to Kimai's defaults (`language: en`, system timezone, `theme: auto`):

```yaml
kimai:
  defaults:
    user:
      language: da
      timezone: Europe/Copenhagen
      theme: default
```

## Why

Danish users were served the English UI because Kimai derives the UI language solely from the `/{_locale}/` URL segment, not the user's preference — so stale `/en/` bookmarks and post-login target URLs kept them in English regardless of their `da` preference. This makes language behave as a real per-user setting and removes the duplicated default values.
