### PR TITLE
Require PHP >=8.4, drop platform pin and custom composer scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-42](https://github.com/itk-kimai/AarhusKommuneBundle/pull/42)
+  Require PHP `>=8.4`, drop the `config.platform` pin and remove the custom
+  `composer.json` scripts (covered by the Taskfile).
+
 ## [1.5.0] - 2026-07-02
 
 * [PR-40](https://github.com/itk-kimai/AarhusKommuneBundle/pull/40)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         }
     ],
     "homepage": "https://github.com/itk-dev/kimai-plugin-AarhusKommuneBundle",
+    "require": {
+        "php": ">=8.4"
+    },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.43",
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -41,9 +44,6 @@
         "audit": {
             "abandoned": "report"
         },
-        "platform": {
-            "php": "8.2.0"
-        },
         "preferred-install": {
             "*": "dist"
         },
@@ -54,33 +54,5 @@
             "name": "Aarhus kommune",
             "require": 21800
         }
-    },
-    "scripts": {
-        "code-analysis": [
-            "@code-analysis/phpstan"
-        ],
-        "code-analysis/phpstan": [
-            "phpstan analyse . --configuration=phpstan.neon"
-        ],
-        "coding-standards-apply": [
-            "@coding-standards-apply/php-cs-fixer",
-            "@coding-standards-apply/twig-cs-fixer"
-        ],
-        "coding-standards-apply/php-cs-fixer": [
-            "php-cs-fixer fix"
-        ],
-        "coding-standards-apply/twig-cs-fixer": [
-            "twig-cs-fixer lint --fix"
-        ],
-        "coding-standards-check": [
-            "@coding-standards-check/php-cs-fixer",
-            "@coding-standards-check/twig-cs-fixer"
-        ],
-        "coding-standards-check/php-cs-fixer": [
-            "php-cs-fixer fix --dry-run --format=checkstyle"
-        ],
-        "coding-standards-check/twig-cs-fixer": [
-            "twig-cs-fixer lint"
-        ]
     }
 }


### PR DESCRIPTION
## Changes

- Declare a minimum PHP version of `>=8.4` in `require` (matches the Kimai server image `itkdev/php8.4-fpm`).
- Drop the `config.platform` pin; resolution follows the actual runtime.
- Remove the custom `composer.json` scripts — they are covered by the Taskfile, and the CI workflows call the tool binaries directly.

## Why

Consistency across the itk-kimai plugins: an explicit, consumer-facing PHP requirement and a single source of truth (the Taskfile) for local commands.